### PR TITLE
Restore README and gitignore changes from SCRD-6921 revert (SCRD-6921)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+suse_sphinx_theme.egg-info/
+suse_sphinx_theme/__pycache__/

--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ To use the SUSE Sphinx theme, do the following:
 
 This theme is derived from the openstackdocstheme at https://github.com/openstack/openstackdocstheme , and is heavily modified.
 
+
+## Building upstream doc with this theme
+Building the upstream OpenStack docs with the SUSE theme is very similar to the Manual Installation described above:
+
+1. Checkout the project with the desired docs (for example: `git clone git://git.openstack.org/openstack/nova`)
+2. Build the local project normally (typically `tox -edocs`), see the local project documentation for details (e.g. doc/source/contributor/development-environment.rst for nova)
+3. Within the docs folder of the project, update conf.py and set `html_theme = 'suse_sphinx_theme'` and add `'suse_sphinx_theme',` to the extensions list (conf.py is typically under doc/source)
+4. Manually install the theme into the tox environment, this will vary a little depending on where the `suse_sphinx_theme` is cloned, for example (from the Nova top level folder in this case) `.tox/docs/bin/pip install -e ~/upstream/suse-sphinx-theme/`
+5. re-run the tox build job `tox -edocs`
+6. the output of the Nova doc build is under `doc/build/html` , other projects may output to a different location


### PR DESCRIPTION
Restore the README.md and .gitignore files that were updated as part of the rebranding work that got reverted. README includes testing instructions, .gitignore ignores some build output