### PR TITLE
Darkened grey highlight for better readability

### DIFF
--- a/suse_sphinx_theme/static/css/native.css
+++ b/suse_sphinx_theme/static/css/native.css
@@ -1,25 +1,25 @@
 .hll { background-color: #919191 }
 .c { color: #999999; font-style: italic } /* Comment */
 .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.g { color: #d0d0d0 } /* Generic */
+.g { color: #505050 } /* Generic */
 .k { color: #6ab825; font-weight: bold } /* Keyword */
-.l { color: #d0d0d0 } /* Literal */
-.n { color: #d0d0d0 } /* Name */
-.o { color: #d0d0d0 } /* Operator */
-.x { color: #d0d0d0 } /* Other */
-.p { color: #d0d0d0 } /* Punctuation */
+.l { color: #505050 } /* Literal */
+.n { color: #505050 } /* Name */
+.o { color: #505050 } /* Operator */
+.x { color: #505050 } /* Other */
+.p { color: #505050 } /* Punctuation */
 .cm { color: #999999; font-style: italic } /* Comment.Multiline */
 .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
 .c1 { color: #999999; font-style: italic } /* Comment.Single */
 .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
 .gd { color: #d22323 } /* Generic.Deleted */
-.ge { color: #d0d0d0; font-style: italic } /* Generic.Emph */
+.ge { color: #505050; font-style: italic } /* Generic.Emph */
 .gr { color: #d22323 } /* Generic.Error */
 .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
 .gi { color: #589819 } /* Generic.Inserted */
 .go { color: #cccccc } /* Generic.Output */
 .gp { color: #aaaaaa } /* Generic.Prompt */
-.gs { color: #d0d0d0; font-weight: bold } /* Generic.Strong */
+.gs { color: #505050; font-weight: bold } /* Generic.Strong */
 .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
 .gt { color: #d22323 } /* Generic.Traceback */
 .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
@@ -28,7 +28,7 @@
 .kp { color: #6ab825 } /* Keyword.Pseudo */
 .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
 .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
-.ld { color: #d0d0d0 } /* Literal.Date */
+.ld { color: #505050 } /* Literal.Date */
 .m { color: #3677a9 } /* Literal.Number */
 .s { color: #ed9d13 } /* Literal.String */
 .na { color: #bbbbbb } /* Name.Attribute */
@@ -36,13 +36,13 @@
 .nc { color: #447fcf; text-decoration: underline } /* Name.Class */
 .no { color: #40ffff } /* Name.Constant */
 .nd { color: #ffa500 } /* Name.Decorator */
-.ni { color: #d0d0d0 } /* Name.Entity */
+.ni { color: #505050 } /* Name.Entity */
 .ne { color: #bbbbbb } /* Name.Exception */
 .nf { color: #447fcf } /* Name.Function */
-.nl { color: #d0d0d0 } /* Name.Label */
+.nl { color: #505050 } /* Name.Label */
 .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
-.nx { color: #d0d0d0 } /* Name.Other */
-.py { color: #d0d0d0 } /* Name.Property */
+.nx { color: #505050 } /* Name.Other */
+.py { color: #505050 } /* Name.Property */
 .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
 .nv { color: #40ffff } /* Name.Variable */
 .ow { color: #6ab825; font-weight: bold } /* Operator.Word */


### PR DESCRIPTION
The current code formatting using a light grey highlighting is hard to read on the white background (first screenshot).

Using a darker shade of grey (second screenshot) improves readability drastically.

### Old color: #d0d0d0

![d0d0d0](https://user-images.githubusercontent.com/1128117/89158477-77b9b700-d56e-11ea-911f-145f703574e0.png)

### New color: #505050

![505050](https://user-images.githubusercontent.com/1128117/89158475-77212080-d56e-11ea-8fa2-4116f8ad0b6e.png)
