### PR TITLE
Override the use of darker highlight color…

### DIFF
--- a/suse_sphinx_theme/static/css/native.css
+++ b/suse_sphinx_theme/static/css/native.css
@@ -2,24 +2,32 @@
 .c { color: #999999; font-style: italic } /* Comment */
 .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .g { color: #505050 } /* Generic */
+pre .g { color: #d0d0d0 }
 .k { color: #6ab825; font-weight: bold } /* Keyword */
 .l { color: #505050 } /* Literal */
+pre .l { color: #d0d0d0 }
 .n { color: #505050 } /* Name */
+pre .n { color: #d0d0d0 }
 .o { color: #505050 } /* Operator */
+pre .o { color: #d0d0d0 }
 .x { color: #505050 } /* Other */
+pre .x { color: #d0d0d0 }
 .p { color: #505050 } /* Punctuation */
+pre .p { color: #d0d0d0 }
 .cm { color: #999999; font-style: italic } /* Comment.Multiline */
 .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
 .c1 { color: #999999; font-style: italic } /* Comment.Single */
 .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
 .gd { color: #d22323 } /* Generic.Deleted */
 .ge { color: #505050; font-style: italic } /* Generic.Emph */
+pre .ge { color: #d0d0d0 }
 .gr { color: #d22323 } /* Generic.Error */
 .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
 .gi { color: #589819 } /* Generic.Inserted */
 .go { color: #cccccc } /* Generic.Output */
 .gp { color: #aaaaaa } /* Generic.Prompt */
 .gs { color: #505050; font-weight: bold } /* Generic.Strong */
+pre .gs {color: #d0d0d0 }
 .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
 .gt { color: #d22323 } /* Generic.Traceback */
 .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
@@ -29,6 +37,7 @@
 .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
 .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
 .ld { color: #505050 } /* Literal.Date */
+pre .ld {color: #d0d0d0 }
 .m { color: #3677a9 } /* Literal.Number */
 .s { color: #ed9d13 } /* Literal.String */
 .na { color: #bbbbbb } /* Name.Attribute */
@@ -37,12 +46,16 @@
 .no { color: #40ffff } /* Name.Constant */
 .nd { color: #ffa500 } /* Name.Decorator */
 .ni { color: #505050 } /* Name.Entity */
+pre .ni {color: #d0d0d0 }
 .ne { color: #bbbbbb } /* Name.Exception */
 .nf { color: #447fcf } /* Name.Function */
 .nl { color: #505050 } /* Name.Label */
+pre .nl {color: #d0d0d0 }
 .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
 .nx { color: #505050 } /* Name.Other */
+pre .nx { color: #d0d0d0 }
 .py { color: #505050 } /* Name.Property */
+pre .py { color: #d0d0d0 }
 .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
 .nv { color: #40ffff } /* Name.Variable */
 .ow { color: #6ab825; font-weight: bold } /* Operator.Word */


### PR DESCRIPTION
… inside `pre` environment with dark background

When using the new darker highlights in code listings, readability is reduced because the `pre` environment used for code listings uses a dark background color.

This PR adds exceptions to use the old light highlight colors inside the code listings.